### PR TITLE
Update retrolover.py

### DIFF
--- a/retrolover/retrolover.py
+++ b/retrolover/retrolover.py
@@ -134,7 +134,7 @@ def main():
     parser.add_argument('query', type=str, nargs='+', help='search query')
     parser.add_argument('--console', choices=CONSOLES, help='console')
     parser.add_argument('--romsdir', '-r', default='/home/{}/roms'.format(os.getenv('USER')), help='roms directory')
-    args = parser.parse_args()
+    args = parser.parse_args(args)
     for query in args.query:
         url = build_url(args, query, 1)
         romlist = get_rom_list(url, args)


### PR DESCRIPTION
When calling argparse with arguments not from sys.argv you've got to call it with

parser.parse_args(args)